### PR TITLE
Add unique color per tab

### DIFF
--- a/src/renderer/components/RedDotIndicator.tsx
+++ b/src/renderer/components/RedDotIndicator.tsx
@@ -10,7 +10,33 @@ if (typeof document !== 'undefined' && !document.getElementById(SPINNER_ID)) {
   document.head.appendChild(style);
 }
 
-export function StatusDot({ status }: { status: SessionStatus }) {
+// Catppuccin Mocha palette — one color per tab
+export const TAB_COLORS = [
+  '#89b4fa', // blue
+  '#a6e3a1', // green
+  '#f9e2af', // yellow
+  '#cba6f7', // mauve
+  '#f38ba8', // red
+  '#fab387', // peach
+  '#94e2d5', // teal
+  '#f5c2e7', // pink
+  '#74c7ec', // sapphire
+  '#eba0ac', // maroon
+];
+
+export function getTabColor(index: number): string {
+  return TAB_COLORS[index % TAB_COLORS.length];
+}
+
+// Convert hex to rgba for the spinner ring background
+function hexToRgba(hex: string, alpha: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function StatusDot({ status, color = '#89b4fa' }: { status: SessionStatus; color?: string }) {
   if (status === 'active') {
     return (
       <div
@@ -28,8 +54,8 @@ export function StatusDot({ status }: { status: SessionStatus }) {
             width: 10,
             height: 10,
             borderRadius: '50%',
-            border: '2px solid rgba(137, 180, 250, 0.25)',
-            borderTopColor: '#89b4fa',
+            border: `2px solid ${hexToRgba(color, 0.25)}`,
+            borderTopColor: color,
             animation: 'airport-spin 0.8s linear infinite',
             boxSizing: 'border-box',
           }}
@@ -44,7 +70,7 @@ export function StatusDot({ status }: { status: SessionStatus }) {
         width: 8,
         height: 8,
         borderRadius: '50%',
-        backgroundColor: '#89b4fa',
+        backgroundColor: color,
         position: 'absolute',
         top: 5,
         right: 5,

--- a/src/renderer/components/TerminalSquare.tsx
+++ b/src/renderer/components/TerminalSquare.tsx
@@ -6,11 +6,12 @@ import type { TerminalSession } from '../../shared/types';
 interface TerminalSquareProps {
   session: TerminalSession;
   isActive: boolean;
+  tabColor: string;
   onClick: () => void;
   onClose: () => void;
 }
 
-export function TerminalSquare({ session, isActive, onClick, onClose }: TerminalSquareProps) {
+export function TerminalSquare({ session, isActive, tabColor, onClick, onClose }: TerminalSquareProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(session.title);
   const [titleHovered, setTitleHovered] = useState(false);
@@ -48,7 +49,7 @@ export function TerminalSquare({ session, isActive, onClick, onClose }: Terminal
         borderRadius: 6,
         overflow: 'hidden',
         cursor: 'pointer',
-        border: isActive ? '2px solid #89b4fa' : '2px solid #313244',
+        border: isActive ? `2px solid ${tabColor}` : '2px solid #313244',
         background: '#11111b',
         transition: 'border-color 0.15s ease',
         padding: '6px 8px',
@@ -57,7 +58,7 @@ export function TerminalSquare({ session, isActive, onClick, onClose }: Terminal
         gap: 3,
       }}
     >
-      <StatusDot status={session.status} />
+      <StatusDot status={session.status} color={tabColor} />
 
       <button
         onClick={(e) => {

--- a/src/renderer/components/TerminalSquareGrid.tsx
+++ b/src/renderer/components/TerminalSquareGrid.tsx
@@ -1,4 +1,5 @@
 import { TerminalSquare } from './TerminalSquare';
+import { getTabColor } from './RedDotIndicator';
 import { useTerminalStore } from '../store/terminal-store';
 
 interface TerminalSquareGridProps {
@@ -20,11 +21,12 @@ export function TerminalSquareGrid({ onClose }: TerminalSquareGridProps) {
         flex: 1,
       }}
     >
-      {sessions.map((session) => (
+      {sessions.map((session, index) => (
         <TerminalSquare
           key={session.id}
           session={session}
           isActive={session.id === activeSessionId}
+          tabColor={getTabColor(index)}
           onClick={() => setActiveSession(session.id)}
           onClose={() => onClose(session.id)}
         />


### PR DESCRIPTION
## Summary
- Each tab now gets a distinct status dot and active border color instead of all being blue
- Uses a 10-color Catppuccin Mocha palette (blue, green, yellow, mauve, red, peach, teal, pink, sapphire, maroon) that cycles based on tab index
- Spinner ring for active tabs also uses the per-tab color

## Test plan
- [ ] Run `npm start` and open multiple tabs
- [ ] Verify each tab has a different colored dot
- [ ] Verify the active tab border matches its dot color
- [ ] Verify the spinning indicator for active tabs uses the correct color
- [ ] Open 11+ tabs to verify the palette cycles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)