### PR TITLE
Fix tab color changing on reorder

### DIFF
--- a/src/renderer/components/TerminalSquareGrid.tsx
+++ b/src/renderer/components/TerminalSquareGrid.tsx
@@ -81,7 +81,7 @@ export function TerminalSquareGrid({ onClose }: TerminalSquareGridProps) {
           <TerminalSquare
             session={session}
             isActive={session.id === activeSessionId}
-            tabColor={getTabColor(index)}
+            tabColor={getTabColor(session.colorIndex)}
             onClick={() => setActiveSession(session.id)}
             onClose={() => onClose(session.id)}
             draggable

--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -229,9 +229,10 @@ export function usePtyBridge() {
       writeShadowTerminal(sessionId, options.buffer);
     }
 
+    const currentSessions = useTerminalStore.getState().sessions;
     addSession({
       id: sessionId,
-      title: options?.title || `Terminal ${useTerminalStore.getState().sessions.length + 1}`,
+      title: options?.title || `Terminal ${currentSessions.length + 1}`,
       customTitle: options?.customTitle || false,
       status: 'active',
       processName: '',
@@ -242,6 +243,7 @@ export function usePtyBridge() {
       waitingQuestion: '',
       gitRepo: '',
       gitBranch: '',
+      colorIndex: currentSessions.length,
     });
     return sessionId;
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,6 +11,7 @@ export interface TerminalSession {
   waitingQuestion: string;
   gitRepo: string;
   gitBranch: string;
+  colorIndex: number;
 }
 
 export type SessionStatus =


### PR DESCRIPTION
## Summary
- Tab colors were derived from array position (`index`), so dragging a tab to a new position changed its color
- Added a persistent `colorIndex` field to each session, assigned at creation time
- Colors now follow the session, not its position in the list

## Test plan
- [ ] Create multiple terminal tabs and note their colors
- [ ] Drag and drop tabs to reorder them
- [ ] Verify colors remain the same after reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)