### PR TITLE
Fix tab color changing on drag-and-drop reorder

### DIFF
--- a/src/renderer/components/RedDotIndicator.tsx
+++ b/src/renderer/components/RedDotIndicator.tsx
@@ -25,7 +25,8 @@ export const TAB_COLORS = [
 ];
 
 export function getTabColor(index: number): string {
-  return TAB_COLORS[index % TAB_COLORS.length];
+  const i = Number.isFinite(index) ? index : 0;
+  return TAB_COLORS[i % TAB_COLORS.length];
 }
 
 // Convert hex to rgba for the spinner ring background

--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -219,7 +219,7 @@ export function usePtyBridge() {
     };
   }, []);
 
-  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string }) => {
+  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string; colorIndex?: number }) => {
     const { cols, rows } = mainDimsRef.current;
     const sessionId = await window.airport.pty.create({ cols, rows, cwd: options?.cwd });
     createShadowTerminal(sessionId, cols, rows);
@@ -229,10 +229,10 @@ export function usePtyBridge() {
       writeShadowTerminal(sessionId, options.buffer);
     }
 
-    const currentSessions = useTerminalStore.getState().sessions;
+    const store = useTerminalStore.getState();
     addSession({
       id: sessionId,
-      title: options?.title || `Terminal ${currentSessions.length + 1}`,
+      title: options?.title || `Terminal ${store.sessions.length + 1}`,
       customTitle: options?.customTitle || false,
       status: 'active',
       processName: '',
@@ -243,7 +243,7 @@ export function usePtyBridge() {
       waitingQuestion: '',
       gitRepo: '',
       gitBranch: '',
-      colorIndex: currentSessions.length,
+      colorIndex: options?.colorIndex ?? store.nextColorIndex,
     });
     return sessionId;
   };
@@ -277,6 +277,7 @@ export function usePtyBridge() {
       customTitle: session.customTitle,
       cwd: cachedCwds.get(session.id) || '',
       buffer: serializeShadowBuffer(session.id),
+      colorIndex: session.colorIndex,
     }));
 
     const activeIndex = sessions.findIndex((s) => s.id === activeSessionId);
@@ -294,6 +295,7 @@ export function usePtyBridge() {
         title: saved.title,
         customTitle: saved.customTitle,
         buffer: saved.buffer,
+        colorIndex: saved.colorIndex,
       });
       newIds.push(id);
     }

--- a/src/renderer/store/terminal-store.ts
+++ b/src/renderer/store/terminal-store.ts
@@ -4,6 +4,7 @@ import type { TerminalSession, SessionStatus } from '../../shared/types';
 interface TerminalStore {
   sessions: TerminalSession[];
   activeSessionId: string | null;
+  nextColorIndex: number;
 
   addSession: (session: TerminalSession) => void;
   removeSession: (id: string) => void;
@@ -24,11 +25,13 @@ interface TerminalStore {
 export const useTerminalStore = create<TerminalStore>((set) => ({
   sessions: [],
   activeSessionId: null,
+  nextColorIndex: 0,
 
   addSession: (session) =>
     set((state) => ({
-      sessions: [...state.sessions, session],
+      sessions: [...state.sessions, { ...session, colorIndex: session.colorIndex ?? state.nextColorIndex }],
       activeSessionId: state.activeSessionId ?? session.id,
+      nextColorIndex: Math.max(state.nextColorIndex, (session.colorIndex ?? state.nextColorIndex) + 1),
     })),
 
   removeSession: (id) =>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,6 +52,7 @@ export interface SavedSession {
   customTitle: boolean;
   cwd: string;
   buffer: string;
+  colorIndex: number;
 }
 
 export interface SavedState {


### PR DESCRIPTION
## Summary
- Use a monotonically incrementing `nextColorIndex` counter in the store instead of `currentSessions.length`, preventing duplicate color indices when sessions are closed and recreated
- Persist `colorIndex` in `SavedSession` so tab colors survive app restarts
- Handle `undefined`/`NaN` gracefully in `getTabColor`

## Test plan
- [ ] Create 3+ tabs, verify each has a unique color
- [ ] Drag and drop tabs to reorder — colors should follow their tab
- [ ] Close a tab, create a new one, verify it gets a new unique color
- [ ] Restart the app and verify tab colors are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)