### PR TITLE
Add onboarding screen for first-time users

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,6 +3,7 @@ import { TitleBar } from './components/TitleBar';
 import { MainTerminal } from './components/MainTerminal';
 import { TerminalSquareGrid } from './components/TerminalSquareGrid';
 import { SessionControls } from './components/SessionControls';
+import { OnboardingScreen } from './components/OnboardingScreen';
 import { useTerminalStore } from './store/terminal-store';
 import { usePtyBridge } from './hooks/usePtyBridge';
 
@@ -16,14 +17,9 @@ export function App() {
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
   const dragging = useRef(false);
 
-  // Restore previous state or create initial session
+  // Restore previous state (no auto-create — show onboarding if empty)
   useEffect(() => {
-    (async () => {
-      const restored = await restoreState();
-      if (!restored) {
-        await createSession();
-      }
-    })();
+    restoreState();
   }, []);
 
   const handleNewSession = useCallback(async () => {
@@ -90,7 +86,7 @@ export function App() {
 
       if (e.metaKey && e.key === 'w') {
         e.preventDefault();
-        if (activeSessionId && sessions.length > 1) {
+        if (activeSessionId) {
           closeSession(activeSessionId);
         }
         return;
@@ -163,14 +159,19 @@ export function App() {
           overflow: 'hidden',
         }}
       >
-        <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
-          {activeSessionId && (
+        <div style={{ flex: 1, overflow: 'hidden', position: 'relative', display: 'flex' }}>
+          {sessions.length === 0 ? (
+            <OnboardingScreen
+              onNewSession={handleNewSession}
+              onAdoptTerminals={handleAdoptTerminals}
+            />
+          ) : activeSessionId ? (
             <MainTerminal
               key={activeSessionId}
               sessionId={activeSessionId}
               onDimensions={handleDimensions}
             />
-          )}
+          ) : null}
         </div>
 
         {/* Drag handle */}

--- a/src/renderer/components/OnboardingScreen.tsx
+++ b/src/renderer/components/OnboardingScreen.tsx
@@ -1,0 +1,127 @@
+interface OnboardingScreenProps {
+  onNewSession: () => void;
+  onAdoptTerminals: () => void;
+}
+
+export function OnboardingScreen({ onNewSession, onAdoptTerminals }: OnboardingScreenProps) {
+  const buttonBase: React.CSSProperties = {
+    padding: '14px 24px',
+    background: '#313244',
+    color: '#cdd6f4',
+    border: '1px solid #45475a',
+    borderRadius: 8,
+    cursor: 'pointer',
+    fontSize: 14,
+    fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+    transition: 'background 0.15s, border-color 0.15s',
+    width: '100%',
+    textAlign: 'left' as const,
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+  };
+
+  const handleHover = (e: React.MouseEvent, hover: boolean) => {
+    const el = e.currentTarget as HTMLElement;
+    el.style.background = hover ? '#45475a' : '#313244';
+    el.style.borderColor = hover ? '#585b70' : '#45475a';
+  };
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#1e1e2e',
+      }}
+    >
+      <div style={{ maxWidth: 380, width: '100%', padding: '0 32px' }}>
+        <h1
+          style={{
+            color: '#cdd6f4',
+            fontSize: 28,
+            fontWeight: 600,
+            fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+            margin: '0 0 8px 0',
+          }}
+        >
+
+          Welcome to Airport 🛫
+        </h1>
+        <p
+          style={{
+            color: '#6c7086',
+            fontSize: 14,
+            fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+            margin: '0 0 32px 0',
+            lineHeight: 1.5,
+          }}
+        >
+          Where AI agents take off.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          <button
+            onClick={onNewSession}
+            style={buttonBase}
+            onMouseEnter={(e) => handleHover(e, true)}
+            onMouseLeave={(e) => handleHover(e, false)}
+          >
+            <span
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 6,
+                background: '#89b4fa22',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 16,
+                flexShrink: 0,
+              }}
+            >
+              +
+            </span>
+            <div>
+              <div style={{ fontWeight: 500 }}>Start a new session</div>
+              <div style={{ fontSize: 12, color: '#6c7086', marginTop: 2 }}>
+                Open a fresh terminal
+              </div>
+            </div>
+          </button>
+
+          <button
+            onClick={onAdoptTerminals}
+            style={buttonBase}
+            onMouseEnter={(e) => handleHover(e, true)}
+            onMouseLeave={(e) => handleHover(e, false)}
+          >
+            <span
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 6,
+                background: '#a6e3a122',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 16,
+                flexShrink: 0,
+              }}
+            >
+              ~
+            </span>
+            <div>
+              <div style={{ fontWeight: 500 }}>Bring all terminals home</div>
+              <div style={{ fontSize: 12, color: '#6c7086', marginTop: 2 }}>
+                Adopt your open terminal sessions
+              </div>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Show a welcome screen when no sessions exist with two actions: start a new session or bring all terminals home
- Allow closing the last session with Cmd+W to return to the onboarding screen
- No auto-created session on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)