### PR TITLE
Fix sidebar title blinking between icon and plain text views

### DIFF
--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -196,7 +196,12 @@ export function usePtyBridge() {
             if (session.gitRepo !== info.gitRepo || session.gitBranch !== info.gitBranch) {
               setSessionGitInfo(session.id, info.gitRepo, info.gitBranch);
             }
-          } else if (session.gitRepo || session.gitBranch) {
+          } else if (info.cwd && (session.gitRepo || session.gitBranch)) {
+            // Only clear git info when we successfully resolved a cwd but
+            // found no git repo (user genuinely left a git directory).
+            // When cwd is empty the process-tree walk failed transiently
+            // (common while Claude spawns short-lived subprocesses) — keep
+            // the previously detected git info to avoid title blinking.
             setSessionGitInfo(session.id, '', '');
           }
         } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- When Claude spawns short-lived subprocesses, the process-tree walk can fail to resolve a cwd, returning empty git info
- This caused `gitRepo`/`gitBranch` to be cleared every poll cycle, making the sidebar title flash between the icon view and plain "repo/branch" text
- Now only clears git info when we successfully resolved a cwd but found no git repo — transient detection failures preserve the last known git state

## Test plan
- [ ] Open Airport with a terminal in a git repo, verify repo/branch shows with icons
- [ ] Run Claude Code and observe sidebar — title should remain stable with icons (no blinking)
- [ ] `cd` to a non-git directory and verify the title updates appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)