### PR TITLE
Add agent spawn: create terminal tabs from within sessions

### DIFF
--- a/bin/airport-spawn
+++ b/bin/airport-spawn
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# airport-spawn — Request a new Airport terminal tab from within a session.
+#
+# Usage:
+#   airport-spawn [--cwd DIR] [--title TITLE] [--command CMD]
+#
+# Writes a .spawn JSON file that Airport's hook-watcher picks up to create
+# a new PTY session in its own tab.
+
+set -euo pipefail
+
+if [ -z "${AIRPORT_SPAWN_DIR:-}" ]; then
+  echo "Error: AIRPORT_SPAWN_DIR is not set. This script must be run from within an Airport terminal session." >&2
+  exit 1
+fi
+
+if [ ! -d "$AIRPORT_SPAWN_DIR" ]; then
+  echo "Error: Spawn directory $AIRPORT_SPAWN_DIR does not exist. Is Airport running?" >&2
+  exit 1
+fi
+
+CWD=""
+TITLE=""
+COMMAND=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cwd)
+      CWD="$2"
+      shift 2
+      ;;
+    --title)
+      TITLE="$2"
+      shift 2
+      ;;
+    --command)
+      COMMAND="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: airport-spawn [--cwd DIR] [--title TITLE] [--command CMD]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Helper to JSON-escape a string value
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | \
+    awk '{ if (NR>1) printf "\\n"; printf "%s", $0 }'
+}
+
+# Build JSON manually to avoid jq dependency
+JSON="{"
+FIRST=true
+
+if [ -n "$CWD" ]; then
+  JSON="${JSON}\"cwd\":\"$(json_escape "$CWD")\""
+  FIRST=false
+fi
+
+if [ -n "$TITLE" ]; then
+  if [ "$FIRST" = false ]; then JSON="${JSON},"; fi
+  JSON="${JSON}\"title\":\"$(json_escape "$TITLE")\""
+  FIRST=false
+fi
+
+if [ -n "$COMMAND" ]; then
+  if [ "$FIRST" = false ]; then JSON="${JSON},"; fi
+  JSON="${JSON}\"command\":\"$(json_escape "$COMMAND")\""
+fi
+
+JSON="${JSON}}"
+
+SPAWN_FILE="${AIRPORT_SPAWN_DIR}/$(date +%s)-$$.spawn"
+printf '%s' "$JSON" > "$SPAWN_FILE"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Terminal multiplexer for AI coding CLIs",
   "main": ".vite/build/main.js",
   "bin": {
-    "airport-ai": "bin/airport.js"
+    "airport-ai": "bin/airport.js",
+    "airport-spawn": "bin/airport-spawn"
   },
   "files": [
     "bin/",

--- a/scripts/setup-hooks.mjs
+++ b/scripts/setup-hooks.mjs
@@ -83,6 +83,59 @@ if (installed > 0) {
   console.log('✓ Airport hooks already up to date');
 }
 
+// --- Global CLAUDE.md: teach Claude about airport-spawn ---
+const claudeMdPath = join(claudeDir, 'CLAUDE.md');
+const SPAWN_START = '<!-- airport-spawn -->';
+const SPAWN_END = '<!-- /airport-spawn -->';
+const SPAWN_BLOCK = `${SPAWN_START}
+## Airport Agent Spawning
+
+**IMPORTANT: This section ONLY applies when the \`AIRPORT\` environment variable is set (i.e., you are running inside Airport terminal multiplexer). If \`$AIRPORT\` is not set, ignore this section entirely.**
+
+You can spawn parallel agent sessions — each in its own Airport tab with its own git worktree. **Only do this when the user explicitly asks to spawn agents or work in parallel** (e.g., "spawn agents for these tasks", "do these in parallel", "run these as separate agents"). Never spawn agents on your own initiative — if the user gives you multiple tasks without asking for parallel execution, do them sequentially in the current session.
+
+To spawn an agent:
+
+\`\`\`bash
+git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+airport-spawn \\
+  --cwd "$(pwd)/.claude/worktrees/<branch-name>" \\
+  --command "claude --dangerously-skip-permissions '<task prompt>. Create a plan first and wait for my approval before implementing.'"
+\`\`\`
+
+Do not pass --title — the tab will automatically show the git repo and branch name from the worktree.
+Pass the full prompt as an argument to claude (not -p) so it starts an interactive session with the task.
+${SPAWN_END}`;
+
+let claudeMd = '';
+try { claudeMd = readFileSync(claudeMdPath, 'utf-8'); } catch { /* doesn't exist yet */ }
+
+const startIdx = claudeMd.indexOf(SPAWN_START);
+const endIdx = claudeMd.indexOf(SPAWN_END);
+
+if (startIdx === -1) {
+  // Append block (with a leading newline if file has existing content)
+  const separator = claudeMd.length > 0 && !claudeMd.endsWith('\n') ? '\n\n' : claudeMd.length > 0 ? '\n' : '';
+  writeFileSync(claudeMdPath, claudeMd + separator + SPAWN_BLOCK + '\n');
+  console.log(`✓ Airport agent-spawn instructions added to ${claudeMdPath}`);
+} else if (endIdx !== -1) {
+  // Replace between markers
+  const before = claudeMd.slice(0, startIdx);
+  const after = claudeMd.slice(endIdx + SPAWN_END.length);
+  const updated = before + SPAWN_BLOCK + after;
+  if (updated !== claudeMd) {
+    writeFileSync(claudeMdPath, updated);
+    console.log(`✓ Airport agent-spawn instructions updated in ${claudeMdPath}`);
+  } else {
+    console.log('✓ Airport agent-spawn instructions already up to date');
+  }
+} else {
+  // Start marker exists but no end marker (corrupted) — replace from start to EOF
+  const before = claudeMd.slice(0, startIdx);
+  writeFileSync(claudeMdPath, before + SPAWN_BLOCK + '\n');
+  console.log(`✓ Airport agent-spawn instructions repaired in ${claudeMdPath}`);
+}
+
 // --- Worktree support: symlink node_modules from main repo ---
 const localNM = join(projectRoot, 'node_modules');
 try {

--- a/src/main/hook-watcher.ts
+++ b/src/main/hook-watcher.ts
@@ -10,6 +10,9 @@ import { IPC } from '../shared/ipc-channels';
  * Each PTY session has a file at /tmp/airport-{pid}/{sessionId}.status
  * Hook scripts write "busy;message" or "done;message" to these files.
  *
+ * Also watches for .spawn files written by the airport-spawn script.
+ * These request creation of new terminal tabs from within existing sessions.
+ *
  * Uses fs.watch on the status directory for near-instant detection (~ms),
  * with a slow polling fallback as a safety net for missed events.
  */
@@ -46,13 +49,51 @@ export function startHookWatcher(
     }
   }
 
-  // fs.watch on the directory: OS notifies us the moment any .status file changes
+  // Guard against macOS fs.watch firing duplicate events for the same file
+  const processedSpawns = new Set<string>();
+
+  function processSpawnFile(filePath: string) {
+    const basename = path.basename(filePath);
+    if (processedSpawns.has(basename)) return;
+    processedSpawns.add(basename);
+    // Clean up after a short delay to avoid unbounded growth
+    setTimeout(() => processedSpawns.delete(basename), 5000);
+
+    const win = getWindow();
+    if (!win || win.isDestroyed()) return;
+
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8').trim();
+      fs.unlinkSync(filePath);
+    } catch {
+      return;
+    }
+
+    let request: { cwd?: string; command?: string; title?: string };
+    try {
+      request = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    // Forward to renderer — it owns PTY + shadow terminal creation
+    win.webContents.send(IPC.SPAWN_REQUEST, {
+      title: request.title,
+      cwd: request.cwd,
+      command: request.command,
+    });
+  }
+
+  // fs.watch on the directory: OS notifies us the moment any file changes
   let dirWatcher: fs.FSWatcher | undefined;
   try {
     dirWatcher = fs.watch(STATUS_DIR, (_event, filename) => {
       if (filename && filename.endsWith('.status')) {
         const sessionId = filename.slice(0, -7); // strip '.status'
         processSession(sessionId);
+      } else if (filename && filename.endsWith('.spawn')) {
+        processSpawnFile(path.join(STATUS_DIR, filename));
       } else {
         // filename can be null on some platforms — scan all sessions
         for (const sessionId of ptyManager.getAllSessionIds()) {

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -11,6 +11,7 @@ interface PtySession {
 }
 
 const STATUS_DIR = path.join(os.tmpdir(), `airport-${process.pid}`);
+const BIN_DIR = path.join(__dirname, '..', '..', 'bin');
 
 export class PtyManager {
   private sessions = new Map<string, PtySession>();
@@ -29,6 +30,7 @@ export class PtyManager {
     const statusFile = path.join(STATUS_DIR, `${id}.status`);
     const shell = process.env.SHELL || '/bin/zsh';
 
+    const existingPath = process.env.PATH || '';
     const proc = pty.spawn(shell, [], {
       name: 'xterm-256color',
       cols: options.cols,
@@ -41,7 +43,10 @@ export class PtyManager {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         AIRPORT: '1',
+        AIRPORT_PID: String(process.pid),
+        AIRPORT_SPAWN_DIR: STATUS_DIR,
         AIRPORT_STATUS_FILE: statusFile,
+        PATH: `${BIN_DIR}:${existingPath}`,
       } as Record<string, string>,
     });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { IPC } from '../shared/ipc-channels';
-import type { PtyCreateOptions, PtyDataEvent, PtyExitEvent, HookStatusEvent, AirportApi, SessionInfo, SavedState, ExternalTerminal, PlanFile } from '../shared/types';
+import type { PtyCreateOptions, PtyDataEvent, PtyExitEvent, HookStatusEvent, SpawnRequestEvent, AirportApi, SessionInfo, SavedState, ExternalTerminal, PlanFile } from '../shared/types';
 
 const api: AirportApi = {
   pty: {
@@ -52,6 +52,11 @@ const api: AirportApi = {
     const handler = (_event: Electron.IpcRendererEvent, data: HookStatusEvent) => callback(data);
     ipcRenderer.on(IPC.HOOK_STATUS, handler);
     return () => ipcRenderer.removeListener(IPC.HOOK_STATUS, handler);
+  },
+  onSpawnRequest: (callback: (event: SpawnRequestEvent) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: SpawnRequestEvent) => callback(data);
+    ipcRenderer.on(IPC.SPAWN_REQUEST, handler);
+    return () => ipcRenderer.removeListener(IPC.SPAWN_REQUEST, handler);
   },
 };
 

--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -119,6 +119,23 @@ export function usePtyBridge() {
       }
     });
 
+    // Listen for spawn requests from main process (file-based spawn protocol)
+    const unsubSpawn = window.airport.onSpawnRequest(async ({ title, cwd, command }) => {
+      const sessionId = await createSession({
+        cwd,
+        title: title || undefined,
+        customTitle: !!title,
+      });
+      useTerminalStore.getState().setActiveSession(sessionId);
+
+      if (command) {
+        // Single write — shell prompt is ready by now since createSession awaits PTY creation
+        setTimeout(() => {
+          window.airport.pty.write(sessionId, command + '\n');
+        }, 300);
+      }
+    });
+
     // Listen for hook status updates from main process (file-based IPC)
     const unsubHook = window.airport.onHookStatus(({ sessionId, state, message }) => {
       hookStates.set(sessionId, { state, message });
@@ -266,6 +283,7 @@ export function usePtyBridge() {
 
     return () => {
       unsubData();
+      unsubSpawn();
       unsubHook();
       unsubExit();
       unsubSaveRequest();

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -11,6 +11,7 @@ export const IPC = {
   STATE_LOAD: 'state:load',
   STATE_REQUEST_SAVE: 'state:requestSave',
   HOOK_STATUS: 'hook:status',
+  SPAWN_REQUEST: 'spawn:request',
   DISCOVER_TERMINALS: 'terminals:discover',
   PLAN_GET_FILES: 'plan:getFiles',
   PLAN_READ_FILE: 'plan:readFile',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -76,6 +76,12 @@ export interface HookStatusEvent {
   message: string;
 }
 
+export interface SpawnRequestEvent {
+  title?: string;
+  cwd?: string;
+  command?: string;
+}
+
 export interface ExternalTerminal {
   pid: number;
   tty: string;
@@ -98,6 +104,7 @@ export interface AirportApi {
   loadState: () => Promise<SavedState | null>;
   onRequestSave: (callback: () => void) => () => void;
   onHookStatus: (callback: (event: HookStatusEvent) => void) => () => void;
+  onSpawnRequest: (callback: (event: SpawnRequestEvent) => void) => () => void;
   discoverTerminals: () => Promise<ExternalTerminal[]>;
   getPlanFiles: (cwd: string) => Promise<PlanFile[]>;
   readPlanFile: (path: string) => Promise<string>;


### PR DESCRIPTION
## Summary
- Adds `airport-spawn` CLI script that lets processes inside Airport request new terminal tabs via a file-based protocol
- Hook-watcher detects `.spawn` files and forwards requests to the renderer, which creates sessions through the normal `createSession` flow
- Exposes `AIRPORT_PID`, `AIRPORT_SPAWN_DIR` env vars and prepends `bin/` to PATH in PTY sessions
- `setup-hooks.mjs` auto-installs agent-spawn instructions into `~/.claude/CLAUDE.md` (idempotent, marker-delimited)
- Includes macOS `fs.watch` dedup guard to prevent double-fire

## Test plan
- [ ] `npm start` — app launches, existing sessions work
- [ ] Verify `echo $AIRPORT_SPAWN_DIR` returns a path in a terminal tab
- [ ] Run `airport-spawn --command "echo hello"` — new tab appears with output
- [ ] Run with `--cwd` pointing to a git worktree — tab title shows repo/branch
- [ ] Spawn two agents simultaneously — both tabs appear and work
- [ ] Verify `~/.claude/CLAUDE.md` has airport-spawn instructions after `npm start`
- [ ] Re-run `npm start` — instructions not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)