### PR TITLE
Add RTL (Hebrew/Arabic) BiDi support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "airport-ai",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "airport-ai",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,6 +16,7 @@
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "bidi-js": "^1.0.3",
         "electron": "40.6.1",
         "electron-squirrel-startup": "^1.0.1",
         "node-pty": "^1.1.0",
@@ -26,7 +27,8 @@
         "zustand": "^5.0.11"
       },
       "bin": {
-        "airport-ai": "bin/airport.js"
+        "airport-ai": "bin/airport.js",
+        "airport-spawn": "bin/airport-spawn"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
@@ -3831,6 +3833,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -10407,7 +10418,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "bidi-js": "^1.0.3",
     "electron": "40.6.1",
     "electron-squirrel-startup": "^1.0.1",
     "node-pty": "^1.1.0",

--- a/src/renderer/components/MainTerminal.tsx
+++ b/src/renderer/components/MainTerminal.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { terminalTheme } from '../lib/theme';
 import { serializeShadowBuffer } from '../lib/terminal-factory';
+import { processBidi } from '../lib/bidi-transform';
 import '@xterm/xterm/css/xterm.css';
 
 interface MainTerminalProps {
@@ -80,7 +81,7 @@ export function MainTerminal({ sessionId, onDimensions }: MainTerminalProps) {
     // Receive PTY output
     const unsubData = window.airport.pty.onData(({ sessionId: sid, data }) => {
       if (sid === sessionId) {
-        term.write(data);
+        term.write(processBidi(data));
       }
     });
 

--- a/src/renderer/lib/bidi-js.d.ts
+++ b/src/renderer/lib/bidi-js.d.ts
@@ -1,0 +1,15 @@
+declare module 'bidi-js' {
+  interface EmbeddingLevelsResult {
+    levels: Uint8Array;
+    paragraphs: Array<{ start: number; end: number; level: number }>;
+  }
+
+  interface BidiInstance {
+    getEmbeddingLevels(text: string, baseDirection?: 'ltr' | 'rtl' | 'auto'): EmbeddingLevelsResult;
+    getReorderedIndices(text: string, result: EmbeddingLevelsResult, start?: number, end?: number): number[];
+    getMirroredCharacter(char: string): string | null;
+  }
+
+  function bidiFactory(): BidiInstance;
+  export default bidiFactory;
+}

--- a/src/renderer/lib/bidi-transform.ts
+++ b/src/renderer/lib/bidi-transform.ts
@@ -1,0 +1,81 @@
+import bidiFactory from 'bidi-js';
+
+const bidi = bidiFactory();
+
+// Matches Hebrew, Arabic, Syriac, Arabic Supplement / Presentation Forms
+const RTL_CHAR_REGEX = /[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\uFB50-\uFDFF\uFE70-\uFEFF]/;
+
+// Matches all common ANSI escape sequences (CSI, OSC, character set designators)
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[()][012AB])/g;
+
+/**
+ * Apply Unicode BiDi visual reordering to terminal output.
+ *
+ * xterm.js renders all characters left-to-right. This function reorders RTL
+ * characters (Hebrew, Arabic, etc.) into visual order so they display correctly.
+ *
+ * Fast-path: returns data unchanged if no RTL characters are detected.
+ */
+export function processBidi(data: string): string {
+  if (!RTL_CHAR_REGEX.test(data)) {
+    return data;
+  }
+
+  const lines = data.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    lines[i] = processLine(lines[i]);
+  }
+  return lines.join('\n');
+}
+
+function processLine(line: string): string {
+  // Quick check: no RTL chars in this line, skip
+  if (!RTL_CHAR_REGEX.test(line)) return line;
+
+  // 1. Strip ANSI escape sequences, record their positions (by plain-text char index)
+  const ansiAtSlot = new Map<number, string>();
+  let plainText = '';
+  let lastIndex = 0;
+
+  ANSI_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ANSI_REGEX.exec(line)) !== null) {
+    plainText += line.substring(lastIndex, match.index);
+    const slot = plainText.length;
+    ansiAtSlot.set(slot, (ansiAtSlot.get(slot) || '') + match[0]);
+    lastIndex = match.index + match[0].length;
+  }
+  plainText += line.substring(lastIndex);
+
+  if (plainText.length === 0) return line;
+  if (!RTL_CHAR_REGEX.test(plainText)) return line;
+
+  // 2. Run BiDi algorithm on the plain text
+  const embeddingLevels = bidi.getEmbeddingLevels(plainText, 'ltr');
+  const reorderedIndices = bidi.getReorderedIndices(plainText, embeddingLevels);
+
+  // 3. Build visual-order plain text (with bracket mirroring for RTL chars)
+  let reorderedChars = '';
+  for (let i = 0; i < reorderedIndices.length; i++) {
+    const origIndex = reorderedIndices[i];
+    if (embeddingLevels.levels[origIndex] & 1) {
+      // RTL character — apply mirroring (e.g. '(' ↔ ')')
+      reorderedChars += bidi.getMirroredCharacter(plainText[origIndex]) || plainText[origIndex];
+    } else {
+      reorderedChars += plainText[origIndex];
+    }
+  }
+
+  // 4. Re-insert ANSI escape codes at their original slot positions
+  if (ansiAtSlot.size === 0) return reorderedChars;
+
+  let result = '';
+  for (let i = 0; i <= reorderedChars.length; i++) {
+    const ansi = ansiAtSlot.get(i);
+    if (ansi) result += ansi;
+    if (i < reorderedChars.length) result += reorderedChars[i];
+  }
+
+  return result;
+}

--- a/src/renderer/lib/terminal-factory.ts
+++ b/src/renderer/lib/terminal-factory.ts
@@ -1,6 +1,7 @@
 import { Terminal } from '@xterm/xterm';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { terminalTheme } from './theme';
+import { processBidi } from './bidi-transform';
 
 interface ShadowTerminal {
   terminal: Terminal;
@@ -51,7 +52,7 @@ export function getShadowTerminal(sessionId: string): ShadowTerminal | undefined
 }
 
 export function writeShadowTerminal(sessionId: string, data: string): void {
-  shadowTerminals.get(sessionId)?.terminal.write(data);
+  shadowTerminals.get(sessionId)?.terminal.write(processBidi(data));
 }
 
 export function serializeShadowBuffer(sessionId: string): string {


### PR DESCRIPTION
## Problem

xterm.js renders all characters strictly left-to-right. This means Hebrew, Arabic, and other RTL scripts appear reversed in Airport's terminal — e.g. `echo "שלום עולם"` displays the characters in the wrong order.

## Solution

Intercept PTY output and apply the **Unicode BiDi Algorithm** (via the [`bidi-js`](https://github.com/nicolo-ribaudo/bidi-js) library) to reorder RTL characters into correct visual order before calling `term.write()`.

The transform:
1. **Fast-path bypass** — if no RTL characters are detected, data passes through unchanged (zero overhead for LTR-only sessions)
2. Strips ANSI escape sequences and records their positions
3. Runs the BiDi algorithm on the plain text with LTR base direction
4. Applies bracket mirroring for RTL spans (e.g. `(` ↔ `)`)
5. Re-inserts ANSI escape codes at their original positions

## Files changed

| File | Change |
|------|--------|
| `src/renderer/lib/bidi-transform.ts` | **New** — `processBidi()` function implementing the BiDi transform |
| `src/renderer/lib/bidi-js.d.ts` | **New** — TypeScript declarations for `bidi-js` |
| `src/renderer/components/MainTerminal.tsx` | Wrap `term.write(data)` → `term.write(processBidi(data))` |
| `src/renderer/lib/terminal-factory.ts` | Same wrap for shadow terminal writes |
| `package.json` / `package-lock.json` | Add `bidi-js` ^1.0.3 dependency |

## Testing

```bash
# Basic Hebrew
echo "שלום עולם"

# Mixed LTR + RTL
echo "Hello שלום World"

# ANSI-colored Hebrew
echo -e "\e[31mשלום\e[0m \e[32mעולם\e[0m"

# Arabic
echo "مرحبا بالعالم"
```

## Known limitations

- **Cursor positioning during interactive RTL editing** — the cursor may not track correctly when editing inline RTL text (e.g. in bash readline), since xterm.js cursor movement is LTR-based
- **Minor artifacts with ANSI codes at direction boundaries** — ANSI codes are re-inserted at their original character positions, which may occasionally misalign at LTR↔RTL transition points