### PR TITLE
Add workspaces with swipe gesture navigation

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useCallback, useState, useRef } from 'react';
 import { TitleBar } from './components/TitleBar';
 import { MainTerminal } from './components/MainTerminal';
-import { TerminalSquareGrid } from './components/TerminalSquareGrid';
 import { SessionControls } from './components/SessionControls';
 import { OnboardingScreen } from './components/OnboardingScreen';
 import { PlanReviewPanel } from './components/PlanReviewPanel';
+import { WorkspaceDots } from './components/WorkspaceDots';
+import { WorkspaceContainer } from './components/WorkspaceContainer';
 import { useTerminalStore } from './store/terminal-store';
 import { usePtyBridge } from './hooks/usePtyBridge';
 
@@ -13,10 +14,11 @@ const MIN_SIDEBAR_WIDTH = 200;
 const MAX_SIDEBAR_WIDTH = 600;
 
 export function App() {
-  const { sessions, activeSessionId, previousSessionId, setActiveSession, planViewSessionId, planViewPath } = useTerminalStore();
+  const { sessions, activeSessionId, previousSessionId, setActiveSession, planViewSessionId, planViewPath, workspaces, activeWorkspaceId, setActiveWorkspace } = useTerminalStore();
   const { createSession, closeSession, setMainDimensions, restoreState, clearTerminal } = usePtyBridge();
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
   const dragging = useRef(false);
+  const sidebarRef = useRef<HTMLDivElement>(null);
 
   // Restore previous state (no auto-create — show onboarding if empty)
   useEffect(() => {
@@ -101,9 +103,30 @@ export function App() {
         return;
       }
 
+      // Workspace switching: Ctrl+Cmd+] / Ctrl+Cmd+[
+      if (e.ctrlKey && e.metaKey && e.key === ']') {
+        e.preventDefault();
+        const idx = workspaces.findIndex((w) => w.id === activeWorkspaceId);
+        if (workspaces.length > 1) {
+          setActiveWorkspace(workspaces[(idx + 1) % workspaces.length].id);
+        }
+        return;
+      }
+
+      if (e.ctrlKey && e.metaKey && e.key === '[') {
+        e.preventDefault();
+        const idx = workspaces.findIndex((w) => w.id === activeWorkspaceId);
+        if (workspaces.length > 1) {
+          setActiveWorkspace(workspaces[(idx - 1 + workspaces.length) % workspaces.length].id);
+        }
+        return;
+      }
+
+      // Session shortcuts scoped to active workspace
+      const visible = sessions.filter((s) => !s.backlog && s.workspaceId === activeWorkspaceId);
+
       if (e.metaKey && e.key >= '1' && e.key <= '9') {
         e.preventDefault();
-        const visible = sessions.filter((s) => !s.backlog);
         const idx = parseInt(e.key) - 1;
         if (idx < visible.length) {
           setActiveSession(visible[idx].id);
@@ -113,7 +136,6 @@ export function App() {
 
       if (e.metaKey && e.key === ']') {
         e.preventDefault();
-        const visible = sessions.filter((s) => !s.backlog);
         const idx = visible.findIndex((s) => s.id === activeSessionId);
         if (visible.length > 0) {
           setActiveSession(visible[(idx + 1) % visible.length].id);
@@ -123,7 +145,6 @@ export function App() {
 
       if (e.metaKey && e.key === '[') {
         e.preventDefault();
-        const visible = sessions.filter((s) => !s.backlog);
         const idx = visible.findIndex((s) => s.id === activeSessionId);
         if (visible.length > 0) {
           setActiveSession(visible[(idx - 1 + visible.length) % visible.length].id);
@@ -133,7 +154,6 @@ export function App() {
 
       if (e.metaKey && e.key === 'j') {
         e.preventDefault();
-        const visible = sessions.filter((s) => !s.backlog);
         const idx = visible.findIndex((s) => s.id === activeSessionId);
         for (let i = 1; i <= visible.length; i++) {
           const candidate = visible[(idx + i) % visible.length];
@@ -156,7 +176,7 @@ export function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeSessionId, sessions, handleNewSession, closeSession, setActiveSession, clearTerminal]);
+  }, [activeSessionId, sessions, handleNewSession, closeSession, setActiveSession, clearTerminal, workspaces, activeWorkspaceId, setActiveWorkspace]);
 
   return (
     <div
@@ -220,6 +240,7 @@ export function App() {
         </div>
 
         <div
+          ref={sidebarRef}
           style={{
             width: sidebarWidth,
             flexShrink: 0,
@@ -229,9 +250,8 @@ export function App() {
             overflow: 'hidden',
           }}
         >
-          <TerminalSquareGrid
-            onClose={closeSession}
-          />
+          <WorkspaceDots />
+          <WorkspaceContainer sidebarWidth={sidebarWidth} onClose={closeSession} sidebarRef={sidebarRef} />
           <SessionControls onNewSession={handleNewSession} onAdoptTerminals={handleAdoptTerminals} />
         </div>
       </div>

--- a/src/renderer/components/SessionControls.tsx
+++ b/src/renderer/components/SessionControls.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { useTerminalStore } from '../store/terminal-store';
 
 interface SessionControlsProps {
   onNewSession: () => void;
@@ -6,6 +7,7 @@ interface SessionControlsProps {
 }
 
 export function SessionControls({ onNewSession, onAdoptTerminals }: SessionControlsProps) {
+  const { workspaces, activeWorkspaceId, addWorkspace, removeWorkspace } = useTerminalStore();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -89,6 +91,61 @@ export function SessionControls({ onNewSession, onAdoptTerminals }: SessionContr
             boxShadow: '0 -4px 12px rgba(0, 0, 0, 0.3)',
           }}
         >
+          <button
+            onClick={() => {
+              setMenuOpen(false);
+              addWorkspace();
+            }}
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              background: 'transparent',
+              color: '#cdd6f4',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: 13,
+              fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+              textAlign: 'left',
+              transition: 'background 0.15s',
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.background = '#45475a';
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.background = 'transparent';
+            }}
+          >
+            New Workspace
+          </button>
+          {workspaces.length > 1 && (
+            <button
+              onClick={() => {
+                setMenuOpen(false);
+                removeWorkspace(activeWorkspaceId);
+              }}
+              style={{
+                width: '100%',
+                padding: '10px 12px',
+                background: 'transparent',
+                color: '#f38ba8',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 13,
+                fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+                textAlign: 'left',
+                transition: 'background 0.15s',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLElement).style.background = '#45475a';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLElement).style.background = 'transparent';
+              }}
+            >
+              Delete Workspace
+            </button>
+          )}
+          <div style={{ height: 1, background: '#45475a', margin: '0' }} />
           <button
             onClick={() => {
               setMenuOpen(false);

--- a/src/renderer/components/TerminalSquareGrid.tsx
+++ b/src/renderer/components/TerminalSquareGrid.tsx
@@ -5,15 +5,16 @@ import { useTerminalStore } from '../store/terminal-store';
 
 interface TerminalSquareGridProps {
   onClose: (sessionId: string) => void;
+  workspaceId: string;
 }
 
 type DragSource = { sessionId: string; zone: 'normal' | 'backlog'; globalIndex: number };
 
-export function TerminalSquareGrid({ onClose }: TerminalSquareGridProps) {
+export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridProps) {
   const { sessions, activeSessionId, setActiveSession, reorderSession, moveToBacklog, restoreFromBacklog } = useTerminalStore();
 
-  const normalSessions = sessions.filter((s) => !s.backlog);
-  const backlogSessions = sessions.filter((s) => s.backlog);
+  const normalSessions = sessions.filter((s) => !s.backlog && s.workspaceId === workspaceId);
+  const backlogSessions = sessions.filter((s) => s.backlog && s.workspaceId === workspaceId);
 
   const [dragSource, setDragSource] = useState<DragSource | null>(null);
   const [dropTarget, setDropTarget] = useState<{ zone: 'normal' | 'backlog' | 'backlog-header'; index: number } | null>(null);

--- a/src/renderer/components/WorkspaceContainer.tsx
+++ b/src/renderer/components/WorkspaceContainer.tsx
@@ -1,0 +1,279 @@
+import { useRef, useEffect, useCallback, type RefObject } from 'react';
+import { useTerminalStore } from '../store/terminal-store';
+import { TerminalSquareGrid } from './TerminalSquareGrid';
+
+interface WorkspaceContainerProps {
+  sidebarWidth: number;
+  onClose: (sessionId: string) => void;
+  sidebarRef: RefObject<HTMLDivElement | null>;
+}
+
+const SNAP_DURATION = 300;
+const SNAP_EASING = 'cubic-bezier(0.25, 0.46, 0.45, 0.94)';
+const RUBBER_BAND_FACTOR = 0.3;
+const VELOCITY_THRESHOLD = 0.3; // px/ms
+const DISTANCE_THRESHOLD = 50; // px — immediate commit once exceeded
+const LOCK_RELEASE_DELAY = 50; // ms of silence before unlocking (short — macOS cancels momentum on finger placement)
+const GESTURE_END_DELAY = 150; // ms — snap back incomplete gesture after pause
+const MIN_LOCK_MS = 80; // minimum lock duration — no acceleration detection during initial momentum burst
+
+export function WorkspaceContainer({ sidebarWidth, onClose, sidebarRef }: WorkspaceContainerProps) {
+  const { workspaces, activeWorkspaceId, setActiveWorkspace } = useTerminalStore();
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  const gestureRef = useRef({
+    active: false,
+    committed: false,
+    locked: false,
+    cumDeltaX: 0,
+    velocity: 0,
+    lastTimestamp: 0,
+    endTimer: null as ReturnType<typeof setTimeout> | null,
+    committedSign: 0, // sign of cumDeltaX when committed (for direction reversal detection)
+    minAbsDeltaDuringLock: Infinity, // tracks momentum deceleration valley
+    lockTime: 0, // timestamp when lock was set
+  });
+
+  const activeIndex = workspaces.findIndex((w) => w.id === activeWorkspaceId);
+  const baseOffset = -(activeIndex * sidebarWidth);
+
+  // Keep latest values accessible in the wheel handler without re-attaching
+  const stateRef = useRef({ activeIndex, sidebarWidth, workspaceCount: workspaces.length, baseOffset });
+  stateRef.current = { activeIndex, sidebarWidth, workspaceCount: workspaces.length, baseOffset };
+
+  const setActiveWorkspaceRef = useRef(setActiveWorkspace);
+  setActiveWorkspaceRef.current = setActiveWorkspace;
+
+  const workspacesRef = useRef(workspaces);
+  workspacesRef.current = workspaces;
+
+  // Apply strip position directly via DOM (no re-render)
+  const applyTransform = useCallback((offset: number, animate: boolean) => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const { baseOffset } = stateRef.current;
+    strip.style.transition = animate ? `transform ${SNAP_DURATION}ms ${SNAP_EASING}` : 'none';
+    strip.style.transform = `translateX(${baseOffset + offset}px)`;
+  }, []);
+
+  // Commit gesture: animate to target workspace, lock, sync store immediately
+  const commitGesture = useCallback((direction: -1 | 0 | 1) => {
+    const g = gestureRef.current;
+    const { activeIndex, sidebarWidth, workspaceCount } = stateRef.current;
+
+    g.committed = true;
+    g.locked = true;
+    g.lockTime = Date.now();
+    g.committedSign = Math.sign(g.cumDeltaX);
+    g.minAbsDeltaDuringLock = Infinity;
+
+    let targetIndex = activeIndex;
+    if (direction === -1 && activeIndex > 0) targetIndex = activeIndex - 1;
+    if (direction === 1 && activeIndex < workspaceCount - 1) targetIndex = activeIndex + 1;
+
+    // Animate strip to target position relative to current base
+    const targetOffset = (activeIndex - targetIndex) * sidebarWidth;
+    applyTransform(targetOffset, true);
+
+    // Sync store immediately — React re-render updates baseOffset to match
+    // where the strip already is, so no visual glitch
+    if (targetIndex !== activeIndex) {
+      setActiveWorkspaceRef.current(workspacesRef.current[targetIndex].id);
+    }
+  }, [applyTransform]);
+
+  // Snap back (rubber-band or cancelled gesture)
+  const snapBack = useCallback(() => {
+    applyTransform(0, true);
+  }, [applyTransform]);
+
+  // Snap to base position when activeWorkspaceId changes (keyboard, dot click, or commit)
+  useEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const g = gestureRef.current;
+    // Reset gesture progress but preserve lock — momentum events still need blocking.
+    // Lock releases via endTimer or direction reversal detection.
+    g.active = false;
+    g.committed = false;
+    g.cumDeltaX = 0;
+    g.velocity = 0;
+    // Animate to new position
+    applyTransform(0, true);
+  }, [activeWorkspaceId, applyTransform]);
+
+  // Wheel listener on sidebar (covers dots + grid + controls)
+  useEffect(() => {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only handle horizontal swipes
+      if (Math.abs(e.deltaX) < Math.abs(e.deltaY) * 0.5) return;
+      if (Math.abs(e.deltaX) < 2) return;
+
+      e.preventDefault();
+
+      const g = gestureRef.current;
+      const now = Date.now();
+
+      // If locked, check if this is a new gesture (not momentum)
+      if (g.locked) {
+        const eventSign = Math.sign(-e.deltaX);
+        const absDelta = Math.abs(e.deltaX);
+        const lockAge = now - g.lockTime;
+
+        // Track the momentum valley (minimum |deltaX| seen during lock)
+        g.minAbsDeltaDuringLock = Math.min(g.minAbsDeltaDuringLock, absDelta);
+
+        // Direction reversal (back-and-forth) — always instant, regardless of lock age
+        const directionReversed = eventSign !== 0 && eventSign !== g.committedSign;
+
+        // Acceleration from valley (same-direction new gesture) —
+        // only after MIN_LOCK_MS to avoid momentum jitter during the initial burst.
+        // Momentum decelerates monotonically; a new gesture accelerates from the valley.
+        // *2 threshold is safe: momentum jitter is ±2-5%, never doubles.
+        const accelerating = lockAge >= MIN_LOCK_MS && absDelta >= g.minAbsDeltaDuringLock * 2;
+
+        if (directionReversed || accelerating) {
+          // New gesture detected — break lock
+          g.locked = false;
+          g.committed = false;
+          g.active = false;
+          g.cumDeltaX = 0;
+          g.velocity = 0;
+          g.committedSign = 0;
+          g.minAbsDeltaDuringLock = Infinity;
+          if (g.endTimer) { clearTimeout(g.endTimer); g.endTimer = null; }
+          // Fall through to process as new gesture start below
+        } else {
+          // Momentum — consume silently, reset release timer
+          if (g.endTimer) clearTimeout(g.endTimer);
+          g.endTimer = setTimeout(() => {
+            g.active = false;
+            g.committed = false;
+            g.locked = false;
+            g.cumDeltaX = 0;
+            g.velocity = 0;
+            g.committedSign = 0;
+            g.minAbsDeltaDuringLock = Infinity;
+          }, LOCK_RELEASE_DELAY);
+          return;
+        }
+      }
+
+      // Start new gesture
+      if (!g.active) {
+        g.active = true;
+        g.committed = false;
+        g.cumDeltaX = 0;
+        g.velocity = 0;
+        g.lastTimestamp = 0;
+      }
+
+      // Track velocity
+      if (g.lastTimestamp > 0) {
+        const dt = now - g.lastTimestamp;
+        if (dt > 0) {
+          g.velocity = -e.deltaX / dt;
+        }
+      }
+      g.lastTimestamp = now;
+      g.cumDeltaX += -e.deltaX;
+
+      const { activeIndex, workspaceCount } = stateRef.current;
+
+      // Check if we should commit immediately
+      const fastFlick = Math.abs(g.velocity) > VELOCITY_THRESHOLD;
+      const distanceExceeded = Math.abs(g.cumDeltaX) > DISTANCE_THRESHOLD;
+
+      if (fastFlick || distanceExceeded) {
+        const direction = g.cumDeltaX > 0 ? -1 : 1; // positive cumDelta = swiped right = go to previous
+        // Only commit if there's actually a workspace in that direction
+        const canGo = (direction === -1 && activeIndex > 0) || (direction === 1 && activeIndex < workspaceCount - 1);
+        if (canGo) {
+          commitGesture(direction as -1 | 1);
+        } else {
+          // At edge — snap back with rubber-band release
+          snapBack();
+          g.committed = true;
+          g.locked = true;
+          g.lockTime = Date.now();
+          g.committedSign = Math.sign(g.cumDeltaX);
+          g.minAbsDeltaDuringLock = Infinity;
+        }
+        // Set end timer to release lock after momentum stops
+        if (g.endTimer) clearTimeout(g.endTimer);
+        g.endTimer = setTimeout(() => {
+          g.active = false;
+          g.committed = false;
+          g.locked = false;
+          g.cumDeltaX = 0;
+          g.velocity = 0;
+          g.committedSign = 0;
+          g.minAbsDeltaDuringLock = Infinity;
+        }, LOCK_RELEASE_DELAY);
+        return;
+      }
+
+      // Not committed yet — update strip position via DOM
+      let offset = g.cumDeltaX;
+      const atStart = activeIndex === 0 && offset > 0;
+      const atEnd = activeIndex === workspaceCount - 1 && offset < 0;
+      if (atStart || atEnd) {
+        offset = offset * RUBBER_BAND_FACTOR;
+      }
+      applyTransform(offset, false);
+
+      // Debounce gesture end — if user stops before threshold, snap back
+      if (g.endTimer) clearTimeout(g.endTimer);
+      g.endTimer = setTimeout(() => {
+        if (g.active && !g.committed) {
+          snapBack();
+          g.active = false;
+          g.cumDeltaX = 0;
+          g.velocity = 0;
+        }
+      }, GESTURE_END_DELAY);
+    };
+
+    sidebar.addEventListener('wheel', handleWheel, { passive: false });
+    return () => sidebar.removeEventListener('wheel', handleWheel);
+  }, [sidebarRef, applyTransform, commitGesture, snapBack]);
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      <div
+        ref={stripRef}
+        style={{
+          display: 'flex',
+          height: '100%',
+          transform: `translateX(${baseOffset}px)`,
+          willChange: 'transform',
+        }}
+      >
+        {workspaces.map((ws) => (
+          <div
+            key={ws.id}
+            style={{
+              width: sidebarWidth,
+              flexShrink: 0,
+              overflow: 'hidden',
+            }}
+          >
+            <TerminalSquareGrid
+              onClose={onClose}
+              workspaceId={ws.id}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/WorkspaceDots.tsx
+++ b/src/renderer/components/WorkspaceDots.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef, useEffect } from 'react';
+import { useTerminalStore } from '../store/terminal-store';
+
+export function WorkspaceDots() {
+  const { workspaces, activeWorkspaceId, setActiveWorkspace, renameWorkspace } = useTerminalStore();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  const commitRename = () => {
+    const trimmed = draft.trim();
+    if (trimmed && activeWorkspace) {
+      renameWorkspace(activeWorkspaceId, trimmed);
+    }
+    setEditing(false);
+  };
+
+  const startEditing = () => {
+    if (activeWorkspace) {
+      setDraft(activeWorkspace.name);
+      setEditing(true);
+    }
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      padding: '10px 8px 4px',
+      gap: 4,
+      flexShrink: 0,
+    }}>
+      {/* Dot indicators */}
+      <div style={{
+        display: 'flex',
+        gap: 6,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+        {workspaces.map((ws) => (
+          <button
+            key={ws.id}
+            onClick={() => setActiveWorkspace(ws.id)}
+            style={{
+              width: ws.id === activeWorkspaceId ? 8 : 6,
+              height: ws.id === activeWorkspaceId ? 8 : 6,
+              borderRadius: '50%',
+              background: ws.id === activeWorkspaceId ? '#cdd6f4' : '#585b70',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              transition: 'all 0.2s ease',
+              opacity: ws.id === activeWorkspaceId ? 1 : 0.6,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Workspace name */}
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitRename();
+            if (e.key === 'Escape') setEditing(false);
+          }}
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#cdd6f4',
+            fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+            background: '#313244',
+            border: '1px solid #585b70',
+            borderRadius: 3,
+            outline: 'none',
+            padding: '1px 6px',
+            textAlign: 'center',
+            width: 120,
+          }}
+        />
+      ) : (
+        <span
+          onDoubleClick={startEditing}
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#6c7086',
+            fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+            cursor: 'default',
+            userSelect: 'none',
+          }}
+        >
+          {activeWorkspace?.name || 'Workspace'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -291,7 +291,7 @@ export function usePtyBridge() {
     };
   }, []);
 
-  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string; colorIndex?: number }) => {
+  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string; colorIndex?: number; workspaceId?: string }) => {
     const { cols, rows } = mainDimsRef.current;
     // Inherit cwd from the active session when not explicitly provided
     let cwd = options?.cwd;
@@ -325,6 +325,7 @@ export function usePtyBridge() {
       backlog: false,
       cwd: cwd || '',
       planFiles: [],
+      workspaceId: options?.workspaceId || store.activeWorkspaceId,
     });
     return sessionId;
   };
@@ -353,7 +354,7 @@ export function usePtyBridge() {
   const getHookMessage = (sessionId: string) => hookStates.get(sessionId)?.message || '';
 
   const saveAllSessions = () => {
-    const { sessions, activeSessionId } = useTerminalStore.getState();
+    const { sessions, activeSessionId, workspaces, activeWorkspaceId } = useTerminalStore.getState();
     const saved: SavedSession[] = sessions.map((session) => ({
       title: session.title,
       customTitle: session.customTitle,
@@ -361,15 +362,27 @@ export function usePtyBridge() {
       buffer: serializeShadowBuffer(session.id),
       colorIndex: session.colorIndex,
       backlog: session.backlog || undefined,
+      workspaceId: session.workspaceId,
     }));
 
     const activeIndex = sessions.findIndex((s) => s.id === activeSessionId);
-    window.airport.saveState({ sessions: saved, activeIndex: Math.max(activeIndex, 0) });
+    window.airport.saveState({
+      sessions: saved,
+      activeIndex: Math.max(activeIndex, 0),
+      workspaces,
+      activeWorkspaceId,
+    });
   };
 
   const restoreState = async (): Promise<boolean> => {
     const state = await window.airport.loadState();
     if (!state || state.sessions.length === 0) return false;
+
+    // Restore workspaces (migration: if none saved, use default)
+    const defaultWsId = 'default';
+    if (state.workspaces && state.workspaces.length > 0) {
+      useTerminalStore.getState().setWorkspaces(state.workspaces, state.activeWorkspaceId || defaultWsId);
+    }
 
     const newIds: string[] = [];
     for (const saved of state.sessions) {
@@ -379,6 +392,7 @@ export function usePtyBridge() {
         customTitle: saved.customTitle,
         buffer: saved.buffer,
         colorIndex: saved.colorIndex,
+        workspaceId: saved.workspaceId || defaultWsId,
       });
       if (saved.backlog) {
         useTerminalStore.getState().updateSession(id, { backlog: true });

--- a/src/renderer/store/terminal-store.ts
+++ b/src/renderer/store/terminal-store.ts
@@ -1,5 +1,8 @@
 import { create } from 'zustand';
-import type { TerminalSession, SessionStatus, PlanFile } from '../../shared/types';
+import type { TerminalSession, SessionStatus, PlanFile, Workspace } from '../../shared/types';
+
+const DEFAULT_WORKSPACE_ID = 'default';
+const DEFAULT_WORKSPACE: Workspace = { id: DEFAULT_WORKSPACE_ID, name: 'Default' };
 
 interface TerminalStore {
   sessions: TerminalSession[];
@@ -8,6 +11,9 @@ interface TerminalStore {
   nextColorIndex: number;
   planViewSessionId: string | null;
   planViewPath: string | null;
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
+  workspaceActiveSessionIds: Record<string, string>;
 
   addSession: (session: TerminalSession) => void;
   removeSession: (id: string) => void;
@@ -29,6 +35,12 @@ interface TerminalStore {
   setPlanFiles: (id: string, planFiles: PlanFile[]) => void;
   viewPlan: (sessionId: string, path: string) => void;
   closePlanView: () => void;
+  addWorkspace: (name?: string) => void;
+  removeWorkspace: (id: string) => void;
+  renameWorkspace: (id: string, name: string) => void;
+  setActiveWorkspace: (id: string) => void;
+  moveSessionToWorkspace: (sessionId: string, workspaceId: string) => void;
+  setWorkspaces: (workspaces: Workspace[], activeId: string) => void;
 }
 
 export const useTerminalStore = create<TerminalStore>((set) => ({
@@ -38,20 +50,34 @@ export const useTerminalStore = create<TerminalStore>((set) => ({
   nextColorIndex: 0,
   planViewSessionId: null,
   planViewPath: null,
+  workspaces: [DEFAULT_WORKSPACE],
+  activeWorkspaceId: DEFAULT_WORKSPACE_ID,
+  workspaceActiveSessionIds: {},
 
   addSession: (session) =>
     set((state) => ({
-      sessions: [...state.sessions, { ...session, backlog: session.backlog ?? false, colorIndex: session.colorIndex ?? state.nextColorIndex }],
+      sessions: [...state.sessions, {
+        ...session,
+        backlog: session.backlog ?? false,
+        colorIndex: session.colorIndex ?? state.nextColorIndex,
+        workspaceId: session.workspaceId || state.activeWorkspaceId,
+      }],
       activeSessionId: state.activeSessionId ?? session.id,
       nextColorIndex: Math.max(state.nextColorIndex, (session.colorIndex ?? state.nextColorIndex) + 1),
     })),
 
   removeSession: (id) =>
     set((state) => {
+      const removed = state.sessions.find((s) => s.id === id);
       const sessions = state.sessions.filter((s) => s.id !== id);
       let activeSessionId = state.activeSessionId;
       if (activeSessionId === id) {
-        activeSessionId = sessions.length > 0 ? sessions[sessions.length - 1].id : null;
+        // Pick replacement from same workspace first
+        const workspaceId = removed?.workspaceId || state.activeWorkspaceId;
+        const sameWorkspace = sessions.filter((s) => s.workspaceId === workspaceId && !s.backlog);
+        activeSessionId = sameWorkspace.length > 0
+          ? sameWorkspace[sameWorkspace.length - 1].id
+          : sessions.length > 0 ? sessions[sessions.length - 1].id : null;
       }
       const clearPlan = state.planViewSessionId === id;
       return {
@@ -61,12 +87,20 @@ export const useTerminalStore = create<TerminalStore>((set) => ({
       };
     }),
 
-  setActiveSession: (id) => set((state) => ({
-    activeSessionId: id,
-    previousSessionId: state.activeSessionId !== id ? state.activeSessionId : state.previousSessionId,
-    planViewSessionId: null,
-    planViewPath: null,
-  })),
+  setActiveSession: (id) => set((state) => {
+    const session = state.sessions.find((s) => s.id === id);
+    const workspaceActiveSessionIds = { ...state.workspaceActiveSessionIds };
+    if (session) {
+      workspaceActiveSessionIds[session.workspaceId] = id;
+    }
+    return {
+      activeSessionId: id,
+      previousSessionId: state.activeSessionId !== id ? state.activeSessionId : state.previousSessionId,
+      planViewSessionId: null,
+      planViewPath: null,
+      workspaceActiveSessionIds,
+    };
+  }),
 
   updateSession: (id, updates) =>
     set((state) => ({
@@ -203,5 +237,80 @@ export const useTerminalStore = create<TerminalStore>((set) => ({
     set(() => ({
       planViewSessionId: null,
       planViewPath: null,
+    })),
+
+  addWorkspace: (name) =>
+    set((state) => {
+      const id = crypto.randomUUID();
+      const ws: Workspace = { id, name: name || `Workspace ${state.workspaces.length + 1}` };
+      return {
+        workspaces: [...state.workspaces, ws],
+        activeWorkspaceId: id,
+      };
+    }),
+
+  removeWorkspace: (id) =>
+    set((state) => {
+      if (state.workspaces.length <= 1) return state;
+      const idx = state.workspaces.findIndex((w) => w.id === id);
+      if (idx === -1) return state;
+      const remaining = state.workspaces.filter((w) => w.id !== id);
+      // Move orphaned sessions to adjacent workspace
+      const targetId = remaining[Math.min(idx, remaining.length - 1)].id;
+      const sessions = state.sessions.map((s) =>
+        s.workspaceId === id ? { ...s, workspaceId: targetId } : s
+      );
+      const activeWorkspaceId = state.activeWorkspaceId === id ? targetId : state.activeWorkspaceId;
+      // Restore last active session in new workspace
+      const lastActive = state.workspaceActiveSessionIds[activeWorkspaceId];
+      const wsSessionExists = sessions.some((s) => s.id === lastActive && s.workspaceId === activeWorkspaceId);
+      const activeSessionId = wsSessionExists ? lastActive : state.activeSessionId;
+      return { workspaces: remaining, sessions, activeWorkspaceId, activeSessionId };
+    }),
+
+  renameWorkspace: (id, name) =>
+    set((state) => ({
+      workspaces: state.workspaces.map((w) =>
+        w.id === id ? { ...w, name } : w
+      ),
+    })),
+
+  setActiveWorkspace: (id) =>
+    set((state) => {
+      if (state.activeWorkspaceId === id) return state;
+      // Save current session for current workspace
+      const workspaceActiveSessionIds = { ...state.workspaceActiveSessionIds };
+      if (state.activeSessionId) {
+        workspaceActiveSessionIds[state.activeWorkspaceId] = state.activeSessionId;
+      }
+      // Restore last active session in target workspace
+      const lastActive = workspaceActiveSessionIds[id];
+      const wsSessions = state.sessions.filter((s) => s.workspaceId === id && !s.backlog);
+      let activeSessionId: string | null = null;
+      if (lastActive && wsSessions.some((s) => s.id === lastActive)) {
+        activeSessionId = lastActive;
+      } else if (wsSessions.length > 0) {
+        activeSessionId = wsSessions[wsSessions.length - 1].id;
+      }
+      return {
+        activeWorkspaceId: id,
+        activeSessionId: activeSessionId || state.activeSessionId,
+        workspaceActiveSessionIds,
+        planViewSessionId: null,
+        planViewPath: null,
+      };
+    }),
+
+  moveSessionToWorkspace: (sessionId, workspaceId) =>
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === sessionId ? { ...s, workspaceId } : s
+      ),
+    })),
+
+  setWorkspaces: (workspaces, activeId) =>
+    set(() => ({
+      workspaces: workspaces.length > 0 ? workspaces : [DEFAULT_WORKSPACE],
+      activeWorkspaceId: activeId || DEFAULT_WORKSPACE_ID,
     })),
 }));

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,11 @@ export interface PlanFile {
   modifiedAt: number;
 }
 
+export interface Workspace {
+  id: string;
+  name: string;
+}
+
 export interface TerminalSession {
   id: string;
   title: string;
@@ -21,6 +26,7 @@ export interface TerminalSession {
   backlog: boolean;
   cwd: string;
   planFiles: PlanFile[];
+  workspaceId: string;
 }
 
 export type SessionStatus =
@@ -63,11 +69,14 @@ export interface SavedSession {
   buffer: string;
   colorIndex: number;
   backlog?: boolean;
+  workspaceId?: string;
 }
 
 export interface SavedState {
   sessions: SavedSession[];
   activeIndex: number;
+  workspaces?: Workspace[];
+  activeWorkspaceId?: string;
 }
 
 export interface HookStatusEvent {


### PR DESCRIPTION
## Summary
- Add workspace support: multiple workspaces with session scoping, dot indicators, add/remove/rename, keyboard shortcuts (Ctrl+Cmd+]/[), and state persistence
- Implement trackpad swipe gestures using direct DOM manipulation with immediate commit, momentum lock with direction reversal and acceleration detection
- Sidebar-level wheel listener covers dots, grid, and controls

## Test plan
- [x] Two-finger swipe between workspaces — smooth, no overshoot
- [x] Fast flick commits immediately, momentum ignored
- [x] Rapid back-and-forth works without delay
- [x] Same-direction consecutive swipes (1→2→3) work without skipping
- [x] Edge rubber-band snaps back
- [x] Dot clicks and keyboard shortcuts still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)