### PR TITLE
Spawn grouping - parent/child session linking

### DIFF
--- a/src/renderer/components/TerminalSquare.tsx
+++ b/src/renderer/components/TerminalSquare.tsx
@@ -9,13 +9,14 @@ interface TerminalSquareProps {
   tabColor: string;
   onClick: () => void;
   onClose: () => void;
+  childCount?: number;
   draggable?: boolean;
   onDragStart?: (e: React.DragEvent) => void;
   onDragEnd?: (e: React.DragEvent) => void;
   onDragOver?: (e: React.DragEvent) => void;
 }
 
-export function TerminalSquare({ session, isActive, tabColor, onClick, onClose, draggable, onDragStart, onDragEnd, onDragOver }: TerminalSquareProps) {
+export function TerminalSquare({ session, isActive, tabColor, onClick, onClose, childCount, draggable, onDragStart, onDragEnd, onDragOver }: TerminalSquareProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(session.title);
   const [titleHovered, setTitleHovered] = useState(false);
@@ -283,6 +284,26 @@ export function TerminalSquare({ session, isActive, tabColor, onClick, onClose, 
           </svg>
           Review plan
         </button>
+      )}
+
+      {/* Spawn badge */}
+      {childCount != null && childCount > 0 && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          background: 'rgba(137, 180, 250, 0.1)',
+          border: '1px solid rgba(137, 180, 250, 0.3)',
+          borderRadius: 4,
+          padding: '2px 6px',
+          color: '#89b4fa',
+          fontSize: 10,
+          fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+          fontWeight: 600,
+          alignSelf: 'flex-start',
+        }}>
+          {childCount} spawned
+        </div>
       )}
 
       {/* Status bar */}

--- a/src/renderer/components/TerminalSquareGrid.tsx
+++ b/src/renderer/components/TerminalSquareGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { TerminalSquare } from './TerminalSquare';
 import { getTabColor } from './RedDotIndicator';
 import { useTerminalStore } from '../store/terminal-store';
@@ -15,6 +15,34 @@ export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridP
 
   const normalSessions = sessions.filter((s) => !s.backlog && s.workspaceId === workspaceId);
   const backlogSessions = sessions.filter((s) => s.backlog && s.workspaceId === workspaceId);
+
+  // Group children under their parents for display
+  const orderedNormal = useMemo(() => {
+    const childCountMap = new Map<string, number>();
+    const childrenOf = new Map<string, typeof normalSessions>();
+    const roots: typeof normalSessions = [];
+
+    for (const s of normalSessions) {
+      if (s.parentSessionId && normalSessions.some((p) => p.id === s.parentSessionId)) {
+        const existing = childrenOf.get(s.parentSessionId) || [];
+        existing.push(s);
+        childrenOf.set(s.parentSessionId, existing);
+        childCountMap.set(s.parentSessionId, (childCountMap.get(s.parentSessionId) || 0) + 1);
+      } else {
+        roots.push(s);
+      }
+    }
+
+    const result: { session: typeof normalSessions[0]; isChild: boolean; childCount: number }[] = [];
+    for (const root of roots) {
+      result.push({ session: root, isChild: false, childCount: childCountMap.get(root.id) || 0 });
+      const children = childrenOf.get(root.id) || [];
+      for (const child of children) {
+        result.push({ session: child, isChild: true, childCount: 0 });
+      }
+    }
+    return result;
+  }, [normalSessions]);
 
   const [dragSource, setDragSource] = useState<DragSource | null>(null);
   const [dropTarget, setDropTarget] = useState<{ zone: 'normal' | 'backlog' | 'backlog-header'; index: number } | null>(null);
@@ -91,6 +119,7 @@ export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridP
     list: typeof sessions,
     session: typeof sessions[0],
     localIndex: number,
+    options?: { isChild?: boolean; childCount?: number },
   ) => {
     const dragLocalIndex = dragSource?.zone === zone
       ? list.findIndex((s) => s.id === dragSource.sessionId)
@@ -102,7 +131,7 @@ export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridP
     const showCrossZone = isDropTarget && dragSource?.zone !== zone;
 
     return (
-      <div key={session.id} style={{ position: 'relative' }}>
+      <div key={session.id} style={{ position: 'relative', marginLeft: options?.isChild ? 16 : 0 }}>
         {(showAbove || showCrossZone) && (
           <div style={{ position: 'absolute', top: -5, left: 4, right: 4, height: 2, background: '#89b4fa', borderRadius: 1, zIndex: 10 }} />
         )}
@@ -112,6 +141,7 @@ export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridP
           tabColor={getTabColor(session.colorIndex)}
           onClick={() => setActiveSession(session.id)}
           onClose={() => onClose(session.id)}
+          childCount={options?.childCount}
           draggable
           onDragStart={handleDragStart(zone, localIndex, session.id)}
           onDragEnd={clearDrag}
@@ -138,9 +168,9 @@ export function TerminalSquareGrid({ onClose, workspaceId }: TerminalSquareGridP
       onDragOver={handleContainerDragOver}
       onDrop={handleDrop}
     >
-      {/* Normal sessions */}
-      {normalSessions.map((session, index) =>
-        renderSessionItem('normal', normalSessions, session, index)
+      {/* Normal sessions (grouped: children indented under parents) */}
+      {orderedNormal.map(({ session, isChild, childCount }, index) =>
+        renderSessionItem('normal', normalSessions, session, index, { isChild, childCount })
       )}
 
       {/* Empty-state drop zone for restoring from backlog when main list is empty */}

--- a/src/renderer/hooks/usePtyBridge.ts
+++ b/src/renderer/hooks/usePtyBridge.ts
@@ -114,10 +114,12 @@ export function usePtyBridge() {
 
     // Listen for spawn requests from main process (file-based spawn protocol)
     const unsubSpawn = window.airport.onSpawnRequest(async ({ title, cwd, command }) => {
+      const parentId = useTerminalStore.getState().activeSessionId;
       const sessionId = await createSession({
         cwd,
         title: title || undefined,
         customTitle: !!title,
+        parentSessionId: parentId || undefined,
       });
       useTerminalStore.getState().setActiveSession(sessionId);
 
@@ -253,7 +255,7 @@ export function usePtyBridge() {
     };
   }, []);
 
-  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string; colorIndex?: number; workspaceId?: string }) => {
+  const createSession = async (options?: { cwd?: string; title?: string; customTitle?: boolean; buffer?: string; colorIndex?: number; workspaceId?: string; parentSessionId?: string }) => {
     const { cols, rows } = mainDimsRef.current;
     // Inherit cwd from the active session when not explicitly provided
     let cwd = options?.cwd;
@@ -288,6 +290,7 @@ export function usePtyBridge() {
       cwd: cwd || '',
       planFiles: [],
       workspaceId: options?.workspaceId || store.activeWorkspaceId,
+      parentSessionId: options?.parentSessionId,
     });
     return sessionId;
   };
@@ -316,15 +319,23 @@ export function usePtyBridge() {
 
   const saveAllSessions = () => {
     const { sessions, activeSessionId, workspaces, activeWorkspaceId } = useTerminalStore.getState();
-    const saved: SavedSession[] = sessions.map((session) => ({
-      title: session.title,
-      customTitle: session.customTitle,
-      cwd: cachedCwds.get(session.id) || '',
-      buffer: serializeShadowBuffer(session.id),
-      colorIndex: session.colorIndex,
-      backlog: session.backlog || undefined,
-      workspaceId: session.workspaceId,
-    }));
+    const saved: SavedSession[] = sessions.map((session) => {
+      let parentIndex: number | undefined;
+      if (session.parentSessionId) {
+        const idx = sessions.findIndex((s) => s.id === session.parentSessionId);
+        if (idx >= 0) parentIndex = idx;
+      }
+      return {
+        title: session.title,
+        customTitle: session.customTitle,
+        cwd: cachedCwds.get(session.id) || '',
+        buffer: serializeShadowBuffer(session.id),
+        colorIndex: session.colorIndex,
+        backlog: session.backlog || undefined,
+        workspaceId: session.workspaceId,
+        parentIndex,
+      };
+    });
 
     const activeIndex = sessions.findIndex((s) => s.id === activeSessionId);
     window.airport.saveState({
@@ -359,6 +370,14 @@ export function usePtyBridge() {
         useTerminalStore.getState().updateSession(id, { backlog: true });
       }
       newIds.push(id);
+    }
+
+    // Rebuild parent-child relationships from saved indices
+    for (let i = 0; i < state.sessions.length; i++) {
+      const saved = state.sessions[i];
+      if (saved.parentIndex !== undefined && saved.parentIndex >= 0 && saved.parentIndex < newIds.length) {
+        useTerminalStore.getState().updateSession(newIds[i], { parentSessionId: newIds[saved.parentIndex] });
+      }
     }
 
     // Set the previously active session

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -27,6 +27,7 @@ export interface TerminalSession {
   cwd: string;
   planFiles: PlanFile[];
   workspaceId: string;
+  parentSessionId?: string;
 }
 
 export type SessionStatus =
@@ -70,6 +71,7 @@ export interface SavedSession {
   colorIndex: number;
   backlog?: boolean;
   workspaceId?: string;
+  parentIndex?: number;
 }
 
 export interface SavedState {


### PR DESCRIPTION
## Summary

- When a session spawns a new one via `airport-spawn`, the new session is linked as a child of the active session
- Children are shown indented under their parent in the sidebar
- Parent sessions get a small blue badge showing how many sessions they spawned (e.g. "2 spawned")
- Parent-child relationships survive save/restore (stored as index references)

## What changed

- `types.ts` - added `parentSessionId` to `TerminalSession` and `parentIndex` to `SavedSession`
- `usePtyBridge.ts` - spawn handler passes activeSessionId as parent, save/restore handles the mapping
- `TerminalSquareGrid.tsx` - groups children under parents with 16px indent
- `TerminalSquare.tsx` - shows spawn count badge on parent sessions (blue, same style as plan badge)

## Test plan

- [ ] Spawn a session via `airport-spawn` and verify the new tab appears indented under the parent
- [ ] Check that the parent shows a "1 spawned" badge
- [ ] Spawn multiple children and verify badge updates ("2 spawned", etc.)
- [ ] Quit and relaunch - verify parent-child grouping is preserved
- [ ] Create a normal (non-spawned) session and verify it appears at root level with no indentation
- [ ] Drag and drop still works for reordering
- [ ] Backlog section still works normally